### PR TITLE
Allow to partially pass options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cron-validator",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2232,9 +2232,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4778,9 +4778,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
-      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,7 @@ describe('validate', () => {
   })
 
   it('should accept 6 symbols to support seconds if seconds option is true', () => {
-    const valid = isValidCron('* * * * * *', { seconds: true, alias: false })
+    const valid = isValidCron('* * * * * *', { seconds: true })
     expect(valid).toBeTruthy()
   })
 
@@ -27,24 +27,24 @@ describe('validate', () => {
   })
 
   it('should not accept seconds outside of 0-59', () => {
-    const at0 = isValidCron('0 * * * * *', { seconds: true, alias: false })
+    const at0 = isValidCron('0 * * * * *', { seconds: true })
     expect(at0).toBeTruthy()
 
-    const at59 = isValidCron('59 * * * * *', { seconds: true, alias: false })
+    const at59 = isValidCron('59 * * * * *', { seconds: true })
     expect(at59).toBeTruthy()
 
-    const above59 = isValidCron('60 * * * * *', { seconds: true, alias: false })
+    const above59 = isValidCron('60 * * * * *', { seconds: true })
     expect(above59).toBeFalsy()
   })
 
   it('should not accept minutes outside of 0-59', () => {
-    const at0 = isValidCron('* 0 * * * *', { seconds: true, alias: false })
+    const at0 = isValidCron('* 0 * * * *', { seconds: true })
     expect(at0).toBeTruthy()
 
-    const at596Symbols = isValidCron('* 59 * * * *', { seconds: true, alias: false })
+    const at596Symbols = isValidCron('* 59 * * * *', { seconds: true })
     expect(at596Symbols).toBeTruthy()
 
-    const above596Symbols = isValidCron('* 60 * * * *', { seconds: true, alias: false })
+    const above596Symbols = isValidCron('* 60 * * * *', { seconds: true })
     expect(above596Symbols).toBeFalsy()
 
     const at595Symbols = isValidCron('59 * * * *')
@@ -94,40 +94,40 @@ describe('validate', () => {
   })
 
   it('should accept month alias with the alias flag', () => {
-    const jan = isValidCron('* * * jan,JAN *', { seconds: false, alias: true })
+    const jan = isValidCron('* * * jan,JAN *', { alias: true })
     expect(jan).toBeTruthy()
 
-    const feb = isValidCron('* * * feb,FEB *', { seconds: false, alias: true })
+    const feb = isValidCron('* * * feb,FEB *', { alias: true })
     expect(feb).toBeTruthy()
 
-    const mar = isValidCron('* * * mar,MAR *', { seconds: false, alias: true })
+    const mar = isValidCron('* * * mar,MAR *', { alias: true })
     expect(mar).toBeTruthy()
 
-    const apr = isValidCron('* * * apr,APR *', { seconds: false, alias: true })
+    const apr = isValidCron('* * * apr,APR *', { alias: true })
     expect(apr).toBeTruthy()
 
-    const may = isValidCron('* * * may,MAY *', { seconds: false, alias: true })
+    const may = isValidCron('* * * may,MAY *', { alias: true })
     expect(may).toBeTruthy()
 
-    const jun = isValidCron('* * * jun,JUN *', { seconds: false, alias: true })
+    const jun = isValidCron('* * * jun,JUN *', { alias: true })
     expect(jun).toBeTruthy()
 
-    const jul = isValidCron('* * * jul,JUL *', { seconds: false, alias: true })
+    const jul = isValidCron('* * * jul,JUL *', { alias: true })
     expect(jul).toBeTruthy()
 
-    const aug = isValidCron('* * * aug,AUG *', { seconds: false, alias: true })
+    const aug = isValidCron('* * * aug,AUG *', { alias: true })
     expect(aug).toBeTruthy()
 
-    const sep = isValidCron('* * * sep,SEP *', { seconds: false, alias: true })
+    const sep = isValidCron('* * * sep,SEP *', { alias: true })
     expect(sep).toBeTruthy()
 
-    const oct = isValidCron('* * * oct,OCT *', { seconds: false, alias: true })
+    const oct = isValidCron('* * * oct,OCT *', { alias: true })
     expect(oct).toBeTruthy()
 
-    const nov = isValidCron('* * * nov,NOV *', { seconds: false, alias: true })
+    const nov = isValidCron('* * * nov,NOV *', { alias: true })
     expect(nov).toBeTruthy()
 
-    const dec = isValidCron('* * * dec,DEC *', { seconds: false, alias: true })
+    const dec = isValidCron('* * * dec,DEC *', { alias: true })
     expect(dec).toBeTruthy()
   })
 
@@ -137,12 +137,12 @@ describe('validate', () => {
   })
 
   it('should not accept invalid month alias', () => {
-    const valid = isValidCron('* * * january *', { seconds: false, alias: true })
+    const valid = isValidCron('* * * january *', { alias: true })
     expect(valid).toBeFalsy()
   })
 
   it('should not accept month alias as steps', () => {
-    const valid = isValidCron('* * * */jan *', { seconds: false, alias: true })
+    const valid = isValidCron('* * * */jan *', { alias: true })
     expect(valid).toBeFalsy()
   })
 
@@ -158,25 +158,25 @@ describe('validate', () => {
   })
 
   it('should accept weekdays alias with the alias flag', () => {
-    const sun = isValidCron('* * * * sun,SUN', { seconds: false, alias: true })
+    const sun = isValidCron('* * * * sun,SUN', { alias: true })
     expect(sun).toBeTruthy()
 
-    const mon = isValidCron('* * * * mon,MON', { seconds: false, alias: true })
+    const mon = isValidCron('* * * * mon,MON', { alias: true })
     expect(mon).toBeTruthy()
 
-    const tue = isValidCron('* * * * tue,TUE', { seconds: false, alias: true })
+    const tue = isValidCron('* * * * tue,TUE', { alias: true })
     expect(tue).toBeTruthy()
 
-    const wed = isValidCron('* * * * wed,WED', { seconds: false, alias: true })
+    const wed = isValidCron('* * * * wed,WED', { alias: true })
     expect(wed).toBeTruthy()
 
-    const thu = isValidCron('* * * * thu,THU', { seconds: false, alias: true })
+    const thu = isValidCron('* * * * thu,THU', { alias: true })
     expect(thu).toBeTruthy()
 
-    const fri = isValidCron('* * * * fri,FRI', { seconds: false, alias: true })
+    const fri = isValidCron('* * * * fri,FRI', { alias: true })
     expect(fri).toBeTruthy()
 
-    const sat = isValidCron('* * * * sat,SAT', { seconds: false, alias: true })
+    const sat = isValidCron('* * * * sat,SAT', { alias: true })
     expect(sat).toBeTruthy()
   })
 
@@ -186,17 +186,17 @@ describe('validate', () => {
   })
 
   it('should not accept invalid weekdays alias', () => {
-    const valid = isValidCron('* * * * sunday', { seconds: false, alias: true })
+    const valid = isValidCron('* * * * sunday', { alias: true })
     expect(valid).toBeFalsy()
   })
 
   it('should not accept weekdays alias as steps', () => {
-    const valid = isValidCron('* * * * */sun', { seconds: false, alias: true })
+    const valid = isValidCron('* * * * */sun', { alias: true })
     expect(valid).toBeFalsy()
   })
 
   it('should accepts ranges', () => {
-    const validSecond = isValidCron('1-10 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1-10 * * * * *', { seconds: true })
     expect(validSecond).toBeTruthy()
 
     const validMinute = isValidCron('1-10 * * * *')
@@ -216,7 +216,7 @@ describe('validate', () => {
   })
 
   it('should accept list of ranges', () => {
-    const validSecond = isValidCron('1-10,11-20,21-30 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1-10,11-20,21-30 * * * * *', { seconds: true })
     expect(validSecond).toBeTruthy()
 
     const validMinute = isValidCron('1-10,11-20,21-30 * * * *')
@@ -236,7 +236,7 @@ describe('validate', () => {
   })
 
   it('should not accept inverted ranges', () => {
-    const validSecond = isValidCron('10-1,20-11,30-21 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('10-1,20-11,30-21 * * * * *', { seconds: true })
     expect(validSecond).toBeFalsy()
 
     const validMinute = isValidCron('10-1,20-11,30-21 * * * *')
@@ -256,7 +256,7 @@ describe('validate', () => {
   })
 
   it('should accept steps in ranges', () => {
-    const validSecond = isValidCron('1-10/2,21-30/2 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1-10/2,21-30/2 * * * * *', { seconds: true })
     expect(validSecond).toBeTruthy()
 
     const validMinute = isValidCron('1-10/2,11-20/2 * * * *')
@@ -276,7 +276,7 @@ describe('validate', () => {
   })
 
   it('should accept wildcards over steps in ranges', () => {
-    const validSecond = isValidCron('1-10,*/2 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1-10,*/2 * * * * *', { seconds: true })
     expect(validSecond).toBeTruthy()
 
     const validMinute = isValidCron('1-10,*/2 * * * *')
@@ -299,7 +299,7 @@ describe('validate', () => {
     const validSecond = isValidCron('1-10-20 * * * * *')
     expect(validSecond).toBeFalsy()
 
-    const validMinute = isValidCron('1-10-20 * * * *', { seconds: true, alias: false })
+    const validMinute = isValidCron('1-10-20 * * * *', { seconds: true })
     expect(validMinute).toBeFalsy()
 
     const validHour = isValidCron('* 1-10-20 * * *')
@@ -316,7 +316,7 @@ describe('validate', () => {
   })
 
   it('should not accept invalid step', () => {
-    const validSecond = isValidCron('1/10/20 * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1/10/20 * * * * *', { seconds: true })
     expect(validSecond).toBeFalsy()
 
     const validMinute = isValidCron('1/10/20 * * * *')
@@ -336,7 +336,7 @@ describe('validate', () => {
   })
 
   it('should not accept incomplete step', () => {
-    const validSecond = isValidCron('*/ * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('*/ * * * * *', { seconds: true })
     expect(validSecond).toBeFalsy()
 
     const validMinute = isValidCron('*/ * * * *')
@@ -356,7 +356,7 @@ describe('validate', () => {
   })
 
   it('should not accept wildcards as range value', () => {
-    const validSecond = isValidCron('1-* * * * * *', { seconds: true, alias: false })
+    const validSecond = isValidCron('1-* * * * * *', { seconds: true })
     expect(validSecond).toBeFalsy()
 
     const validMinute = isValidCron('1-* * * * *')

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ const monthAlias: { [key: string]: string } = {
   dec: '12'
 }
 
-const hasValidMonths = (months: string, alias: boolean): boolean => {
+const hasValidMonths = (months: string, alias?: boolean): boolean => {
   // Prevents alias to be used as steps
   if (months.search(/\/[a-zA-Z]/) !== -1) {
     return false
@@ -105,7 +105,7 @@ const weekdaysAlias: { [key: string]: string } = {
   sat: '6'
 }
 
-const hasValidWeekdays = (weekdays: string, alias: boolean): boolean => {
+const hasValidWeekdays = (weekdays: string, alias?: boolean): boolean => {
   // Prevents alias to be used as steps
   if (weekdays.search(/\/[a-zA-Z]/) !== -1) {
     return false
@@ -131,7 +131,14 @@ type Options = {
   seconds: boolean
 }
 
-export const isValidCron = (cron: string, options: Options = { alias: false, seconds: false }): boolean => {
+const defaultOptions: Options = {
+  alias: false,
+  seconds: false
+}
+
+export const isValidCron = (cron: string, options?: Partial<Options>): boolean => {
+  options = { ...defaultOptions, ...options }
+
   const splits = split(cron)
 
   if (splits.length > (options.seconds ? 6 : 5) || splits.length < 5) {


### PR DESCRIPTION
According to the [README](https://github.com/TheCloudConnectors/cron-validator#usage), it should be possible to partially pass options to `isValidCron()`.

Generally, this is also better in terms of usability because it is not required to pass default values.
 Currently, there are only two options but in the future there might be more then this will be mandatory.

Thanks for the great package by the way, it is really easy to use and lightweight 💯 