### PR TITLE
Use a more strict parse int to avoid \`1*\` from being accepted

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,20 @@ describe('validate', () => {
     expect(valid).toBeTruthy()
   })
 
+  it('should not accept scalar ending with a wildcard', () => {
+    const wildcardAfterMinute = isValidCron('1* * * * *')
+    expect(wildcardAfterMinute).toBeFalsy()
+
+    const wildcardAfterHour = isValidCron('* 1* * * *')
+    expect(wildcardAfterHour).toBeFalsy()
+
+    const wildcardBeforeMinute = isValidCron('*1 * * * *')
+    expect(wildcardBeforeMinute).toBeFalsy()
+
+    const wildcardBeforeHour = isValidCron('* *1 * * *')
+    expect(wildcardBeforeHour).toBeFalsy()
+  })
+
   it('should not accept seconds outside of 0-59', () => {
     const at0 = isValidCron('0 * * * * *', { seconds: true })
     expect(at0).toBeTruthy()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
+// This comes from the fact that parseInt trims characters coming
+// after digits and consider it a valid int, so `1*` becomes `1`.
+const safeParseInt = (value: string): number => {
+  if (/^\d+$/.test(value)) {
+    return Number(value)
+  } else {
+    return NaN
+  }
+}
+
 const isWildcard = (value: string): boolean => {
   return value === '*'
 }
@@ -14,9 +24,9 @@ const isValidRange = (value: string, start: number, stop: number): boolean => {
   const sides = value.split('-')
   switch (sides.length) {
     case 1:
-      return isWildcard(value) || isInRange(parseInt(value, 10), start, stop)
+      return isWildcard(value) || isInRange(safeParseInt(value), start, stop)
     case 2:
-      const [small, big] = sides.map((side: string): number => parseInt(side, 10))
+      const [small, big] = sides.map((side: string): number => safeParseInt(side))
       return small <= big && isInRange(small, start, stop) && isInRange(big, start, stop)
     default:
       return false


### PR DESCRIPTION
Fixes #6 