### PR TITLE
Support n-th weekday of month

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ cron.isValidCron('* * * * 7', { allowSevenAsSunday: true });
 // true
 ```
 
+The `allowNthWeekdayOfMonth` flag can be enabled to enable expressions denoting n-th weekday of the month:
+
+```js
+const cron = require('cron-validator');
+
+cron.isValidCron('* * * * tue#2');
+// false
+
+cron.isValidCron('* * * * tue#2', { allowNthWeekdayOfMonth: true }); // second Tuesday of each month
+// true
+```
+
 ## Features
 
 - [x] Support seconds.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ cron.isValidCron('* * * * 7', { allowSevenAsSunday: true });
 - [x] Support alias.
 - [x] Support blank day notation with `?` symbol.
 - [x] Support both 0-6 and 1-7 ranges for weekdays.
+- [x] Support n-th weekday of month such as `TUE#2`
 - [ ] ~~Have an explain mode returning the fragments in error.~~
 
 ## Motivations

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -214,7 +214,7 @@ describe('validate', () => {
     expect(valid).toBeFalsy()
   })
 
-  it('should accepts ranges', () => {
+  it('should accept ranges', () => {
     const validSecond = isValidCron('1-10 * * * * *', { seconds: true })
     expect(validSecond).toBeTruthy()
 
@@ -233,6 +233,11 @@ describe('validate', () => {
     const validWeekday = isValidCron('* * * * 0-6')
     expect(validWeekday).toBeTruthy()
   })
+
+  it('should accept ranges regardless of allowNthWeekdayOfMonth flag', () => {
+    const validWeekday = isValidCron('* * * * 0-6', { allowNthWeekdayOfMonth: true });
+    expect(validWeekday).toBeTruthy();
+  });
 
   it('should accept list of ranges', () => {
     const validSecond = isValidCron('1-10,11-20,21-30 * * * * *', { seconds: true })
@@ -482,18 +487,18 @@ describe('validate', () => {
 
   describe('nth weekday', () => {
     it.each([
-      ["1#2"], 
-      ["mon#2"], 
-      ["WED#5"]
+      ['1#2'], 
+      ['mon#2'], 
+      ['WED#5']
     ])('should accept %s', (weekday) => {
       const valid = isValidCron(`* * * * ${weekday}`, { allowNthWeekdayOfMonth: true, alias: true });
       expect(valid).toBeTruthy();
     });
 
     it.each([
-      ["mon-fri#2"],
-      ["mon#2-fri#2"],
-      ["WED#6"]
+      ['mon-fri#2'],
+      ['mon#2-fri#2'],
+      ['WED#6']
     ])('should not accept %s', (weekday) => {
       const valid = isValidCron(`* * * * ${weekday}`, { allowNthWeekdayOfMonth: true, alias: true });
       expect(valid).toBeFalsy();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -479,4 +479,29 @@ describe('validate', () => {
     const validWithAliases = isValidCron('* * ? * ?', { alias: true, allowBlankDay: true })
     expect(validWithAliases).toBeFalsy()
   })
+
+  describe('nth weekday', () => {
+    it.each([
+      ["1#2"], 
+      ["mon#2"], 
+      ["WED#5"]
+    ])('should accept %s', (weekday) => {
+      const valid = isValidCron(`* * * * ${weekday}`, { allowNthWeekdayOfMonth: true, alias: true });
+      expect(valid).toBeTruthy();
+    });
+
+    it.each([
+      ["mon-fri#2"],
+      ["mon#2-fri#2"],
+      ["WED#6"]
+    ])('should not accept %s', (weekday) => {
+      const valid = isValidCron(`* * * * ${weekday}`, { allowNthWeekdayOfMonth: true, alias: true });
+      expect(valid).toBeFalsy();
+    });
+
+    it('should not accept aliases if alias is not set', () => {
+      const valid = isValidCron('* * * * mon#2', { allowNthWeekdayOfMonth: true });
+      expect(valid).toBeFalsy();
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,8 +119,13 @@ const weekdaysAlias: { [key: string]: string } = {
   sat: '6'
 }
 
-const hasValidWeekdays = (weekdays: string, alias?: boolean, allowBlankDay?: boolean, allowSevenAsSunday?: boolean): boolean => {
+type WeekdayOptions = Pick<
+  Options,
+  "alias" | "allowBlankDay" | "allowSevenAsSunday" | "allowNthWeekdayOfMonth"
+>;
 
+const hasValidWeekdays = (weekdays: string, options: WeekdayOptions): boolean => {
+  const { allowBlankDay, alias, allowSevenAsSunday, allowNthWeekdayOfMonth } = options;
   // If there is a question mark, checks if the allowBlankDay flag is set
   if (allowBlankDay && isQuestionMark(weekdays)) {
     return true
@@ -133,15 +138,28 @@ const hasValidWeekdays = (weekdays: string, alias?: boolean, allowBlankDay?: boo
     return false
   }
 
-  if (alias) {
-    const remappedWeekdays = weekdays.toLowerCase().replace(/[a-z]{3}/g, (match: string): string => {
-      return weekdaysAlias[match] === undefined ? match : weekdaysAlias[match]
-    })
-    // If any invalid alias was used, it won't pass the other checks as there will be non-numeric values in the weekdays
-    return validateForRange(remappedWeekdays, 0, allowSevenAsSunday ? 7 : 6)
+  const remappedWeekdays = alias
+    ? weekdays.toLowerCase().replace(/[a-z]{3}/g, (match: string): string => {
+        return weekdaysAlias[match] === undefined
+          ? match
+          : weekdaysAlias[match];
+      })
+    : weekdays;
+  const maxWeekdayNum = allowSevenAsSunday ? 7 : 6;
+  
+  if (allowNthWeekdayOfMonth) {
+    // see https://github.com/Airfooox/cron-validate/blob/b95aae1f3a44ad89dbfc7d1a7fca63f3b697aa14/src/helper.ts#L139
+    // and https://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/crontrigger.html#special-characters
+    const [weekday, occurrence, ...leftOvers] = remappedWeekdays.split('#')
+    if (leftOvers.length !== 0) {
+      return false;
+    }
+
+    return isInRange(safeParseInt(occurrence), 1, 5) &&
+      isInRange(safeParseInt(weekday), 0, maxWeekdayNum);
   }
 
-  return validateForRange(weekdays, 0, allowSevenAsSunday ? 7 : 6)
+  return validateForRange(remappedWeekdays, 0, maxWeekdayNum)
 }
 
 const hasCompatibleDayFormat = (days: string, weekdays: string, allowBlankDay?: boolean) => {
@@ -157,17 +175,19 @@ type Options = {
   seconds: boolean
   allowBlankDay: boolean
   allowSevenAsSunday: boolean
+  allowNthWeekdayOfMonth: boolean
 }
 
 const defaultOptions: Options = {
   alias: false,
   seconds: false,
   allowBlankDay: false,
-  allowSevenAsSunday: false
+  allowSevenAsSunday: false,
+  allowNthWeekdayOfMonth: false,
 }
 
-export const isValidCron = (cron: string, options?: Partial<Options>): boolean => {
-  options = { ...defaultOptions, ...options }
+export const isValidCron = (cron: string, partialOptions?: Partial<Options>): boolean => {
+  const options = { ...defaultOptions, ...partialOptions }
 
   const splits = split(cron)
 
@@ -190,7 +210,7 @@ export const isValidCron = (cron: string, options?: Partial<Options>): boolean =
   checks.push(hasValidHours(hours))
   checks.push(hasValidDays(days, options.allowBlankDay))
   checks.push(hasValidMonths(months, options.alias))
-  checks.push(hasValidWeekdays(weekdays, options.alias, options.allowBlankDay, options.allowSevenAsSunday))
+  checks.push(hasValidWeekdays(weekdays, options))
   checks.push(hasCompatibleDayFormat(days, weekdays, options.allowBlankDay))
 
   return checks.every(Boolean)

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,10 +147,11 @@ const hasValidWeekdays = (weekdays: string, options: WeekdayOptions): boolean =>
     : weekdays;
   const maxWeekdayNum = allowSevenAsSunday ? 7 : 6;
   
-  if (allowNthWeekdayOfMonth) {
+  const splitByHash = remappedWeekdays.split('#');
+  if (allowNthWeekdayOfMonth && splitByHash.length >= 2) {
     // see https://github.com/Airfooox/cron-validate/blob/b95aae1f3a44ad89dbfc7d1a7fca63f3b697aa14/src/helper.ts#L139
     // and https://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/crontrigger.html#special-characters
-    const [weekday, occurrence, ...leftOvers] = remappedWeekdays.split('#')
+    const [weekday, occurrence, ...leftOvers] = splitByHash;
     if (leftOvers.length !== 0) {
       return false;
     }


### PR DESCRIPTION
I've discovered that gitlab uses this library to parse their cron expressions on the frontend while using [fugit](https://github.com/floraison/fugit) on backend.
Fugit supports these `* * * * MON#2` things and we use them occasionally in our company.
Apparently, that very case of cron input that we needed has only a backend validation, so we kind of dodged the issue there. But there must be other places in gitlab where it would lead to inconsistencies.

[Cron-validate](https://github.com/Airfooox/cron-validate) already has this option, called `useNthWeekdayOfMonth`.

## Desired behaviour
```js
cron.isValidCron('* * * * tue#2', someOptions) === true // denoting second Tuesday of each month
```
## Actual behaviour
`false`